### PR TITLE
Bug fixes, adjusted debugging print statements, new signals/functions…

### DIFF
--- a/scenes/battle_screen.tscn
+++ b/scenes/battle_screen.tscn
@@ -6,17 +6,18 @@
 
 [node name="BattleScreen" type="Node2D"]
 script = ExtResource("1_m0yuu")
+_num_turns_left = 10
 
 [node name="Enemy" parent="." instance=ExtResource("2_t5xab")]
 
 [node name="Player" parent="." instance=ExtResource("4_okrt5")]
 
-[node name="AttackButton" type="Button" parent="."]
+[node name="TitleScreenButton" type="Button" parent="."]
 offset_left = 169.0
 offset_top = 57.0
 offset_right = 227.0
 offset_bottom = 88.0
-text = "Attack"
+text = "Return to Title Screen"
 
 [node name="PlayCardsButton" type="Button" parent="."]
 offset_left = 415.0
@@ -26,5 +27,5 @@ offset_bottom = 92.0
 text = "Play Cards
 "
 
-[connection signal="pressed" from="AttackButton" to="." method="_on_attack_button_pressed"]
-[connection signal="pressed" from="PlayCardsButton" to="." method="_on_play_cards_button_pressed"]
+[connection signal="pressed" from="TitleScreenButton" to="." method="_on_title_screen_button_pressed"]
+[connection signal="pressed" from="PlayCardsButton" to="Player" method="_on_play_cards_button_pressed"]

--- a/scripts/battle_screen.gd
+++ b/scripts/battle_screen.gd
@@ -25,7 +25,6 @@ func _process(_delta: float) -> void:
 		# TODO Maybe some state machine stuff bc drawing cards is only for the player...emit signal?
 		# TODO Jamie: disable player button input (this can also be done during the battle phase switch signal, probably a better idea)
 		_drew_cards = false
-		print("ENEMY PHASE")
 		print("Enemy current health:", _enemy.curr_health)
 		
 		if _enemy.curr_health <= 0:
@@ -34,12 +33,11 @@ func _process(_delta: float) -> void:
 		else:
 			_enemy.temp_func()
 	elif _curr_phase == PhaseType.PLAYER:
-		print("PLAYER PHASE")
 		# TODO Jamie: reenable player button input, or probably better to do in battle phase switch signal
 		
 		# TODO could do "else" but technically for future development I am putting an elif...
-		if _enemy.num_turns_left == 0 or _player.curr_health <= 0:
-			print("Number of turns left:", _enemy.num_turns_left)
+		if _num_turns_left == 0 or _player.curr_health <= 0:
+			print("Number of turns left:", _num_turns_left)
 			print("Player current health:", _player.curr_health)
 			print("Switching to lose screen...")
 			# TODO need to decrement num turns left in enemy script
@@ -57,18 +55,13 @@ func _on_switch_battle_phase() -> void:
 		_curr_phase = PhaseType.ENEMY
 		# TODO @Jamie: Disable player input.
 	else:  # Enemy turn just ended
+		# TODO re-enable player input
 		_curr_phase = PhaseType.PLAYER
 		# TODO Jamie: update UI too
 		_num_turns_left -= 1
 
 
 # TODO modify later
-func _on_attack_button_pressed() -> void:
+func _on_title_screen_button_pressed() -> void:
 	print("Switching to title screen...")
 	signals.switch_scene.emit("title_screen")
-
-
-func _on_play_cards_button_pressed() -> void:
-	print("Playing cards...")
-	_player.play_cards()
-	pass # Replace with function body.

--- a/scripts/card.gd
+++ b/scripts/card.gd
@@ -18,7 +18,7 @@ func update_card(spec:CardSpec) -> void:
 	month = spec.month
 	type = spec.type
 	synergy = spec.synergy
-	sprite.texture = spec.sprite.texture
+	sprite.texture = spec.texture
 # TODO look for an InputEvent for when the card is clicked on (need collision shape)
 # TODO then the card should be outlined in blue to indicate it's selected (and set is_selected)
 

--- a/scripts/card_spec.gd
+++ b/scripts/card_spec.gd
@@ -36,6 +36,7 @@ enum Synergy {
 	INO_SHIKA_CHO,  # Butterfly, Deer, Boar
 }
 
+
 var month:Month
 var type:Type
 var synergy:Synergy

--- a/scripts/character.gd
+++ b/scripts/character.gd
@@ -1,17 +1,29 @@
 class_name Character
 extends Node2D
 
-
 @export var max_health:int
 var curr_health:int
-
+var atk_multiplier := 1.0
 
 func _ready() -> void:
 	curr_health = max_health
-	print("curr_health is", curr_health)
+	print("curr_health isc", curr_health)
 	signals.character_hit.connect(_on_character_hit)
+	signals.recover_hp.connect(_on_recover_hp)
+
+
+func _cleanup():
+	# Reset atk multiplier and signal to switch scenes
+	atk_multiplier = 1.0
+	signals.switch_battle_phase.emit()
 
 
 func _on_character_hit(target:Character, dmg:int) -> void:
 	# Internally update health
 	target.curr_health = clampi(target.curr_health - dmg, 0, target.max_health)
+
+
+func _on_recover_hp(target:Character, amount:float) -> void:
+	if 0.0 < amount and amount < 1.0:
+		# Increase by integer amount, not float
+		target.curr_health = clampi(target.current_health * (1.0 + amount), curr_health, target.max_health)

--- a/scripts/damage_engine.gd
+++ b/scripts/damage_engine.gd
@@ -3,7 +3,7 @@ extends Node
 
 
 # TODO
-static func calc_dmg(selected_cards:Array[CardSpec], category:Player.Match) -> int:
+static func calc_dmg(selected_cards:Array[CardSpec], category:Player.Match, atk_multiplier:float) -> int:
 	# If you match by month, you can get an effect multipler
 	# If you match by type, you can get a flat bonus dmg increase
 	var num_selected := len(selected_cards)
@@ -30,7 +30,7 @@ static func calc_dmg(selected_cards:Array[CardSpec], category:Player.Match) -> i
 		
 		bonus_dmg = _calc_bonus_dmg(selected_cards[0].type, num_selected)
 	
-	return (base_dmg * effect_multiplier) + bonus_dmg
+	return (base_dmg * effect_multiplier * atk_multiplier) + bonus_dmg
 
 
 static func _calc_bonus_dmg(type:CardSpec.Type, num_selected:int) -> int:

--- a/scripts/signals.gd
+++ b/scripts/signals.gd
@@ -3,4 +3,5 @@ extends Node
 
 signal switch_scene(next_scene:String)
 signal switch_battle_phase
-signal character_hit(dmg:float)
+signal character_hit(target:Character, dmg:float)
+signal recover_hp(target:Character, dmg:float)


### PR DESCRIPTION
New signal for hp recovery in `Character.gd`. There is also an `atk_multiplier` attribute for buff/debuff, and a `_cleanup()` function that resets the `atk_multiplier` back to `1.0` before emitting a signal to switch scenes, so each Character just needs to call this function when they're done. Resetting the multiplier could also potentially be used to reset effects. The damage engine also incorporates this `atk_multiplier`.

Placeholder "Attack" button has been renamed to "Return to Title Screen".